### PR TITLE
Added ability to use unix socket instead http connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ update_fixtures:
 test-e2e: build collector/fixtures/sys/.unpacked
 	@echo ">> running end-to-end tests"
 	./end-to-end-test.sh
+	@echo ">> running end-to-end tests with unix socket"
+	./end-to-end-test.sh -s
 
 .PHONY: skip-test-e2e
 skip-test-e2e:

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -144,12 +144,7 @@ EOF
 
   if [ ${keep} -eq 0 ]
   then
-    if [ ${socket} -ne 0 ]; then
-      signal="-15"
-    else
-      signal="-9"
-    fi
-    kill ${signal} "$(cat ${tmpdir}/node_exporter.pid)"
+    kill "$(cat ${tmpdir}/node_exporter.pid)"
     # This silences the "Killed" message
     set +e
     wait "$(cat ${tmpdir}/node_exporter.pid)" > /dev/null 2>&1

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/prometheus/node_exporter/https"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -32,7 +33,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/node_exporter/collector"
-	"github.com/prometheus/node_exporter/https"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -147,7 +147,7 @@ func main() {
 	var (
 		socketPath = kingpin.Flag(
 			"web.socket-path",
-			"Path to unix socket file.",
+			"Path to a unix socket file on which to expose metrics and web interface.",
 		).String()
 		socketPermissions = kingpin.Flag(
 			"web.socket-permissions",
@@ -203,21 +203,20 @@ func main() {
 			</html>`))
 	})
 
+	humanAddress := "address " + *listenAddress
+	if *socketPath != "" {
+		humanAddress = "path " + *socketPath
+	}
 	var server *http.Server
+	var serve func() error
+	level.Info(logger).Log("msg", "Listening on", "address", humanAddress)
+	server = &http.Server{}
 	if *socketPath == "" {
-		level.Info(logger).Log("msg", "Listening on", "address", *listenAddress)
 		server = &http.Server{Addr: *listenAddress}
-		go func() {
-			if err := https.Listen(server, *configFile, logger); err != nil {
-				level.Error(logger).Log("err", err)
-				os.Exit(1)
-			}
-		}()
-		<-done
-		level.Info(logger).Log("msg", "Connection closed", "address", *listenAddress)
+		serve = func() error {
+			return https.Listen(server, *configFile, logger)
+		}
 	} else {
-		level.Info(logger).Log("msg", "Listening unix socket on", "path", *socketPath)
-		server = &http.Server{}
 		os.Remove(*socketPath)
 		unixListener, err := net.Listen("unix", *socketPath)
 		if err != nil {
@@ -228,15 +227,18 @@ func main() {
 			level.Error(logger).Log("err", err)
 			os.Exit(1)
 		}
-		go func() {
-			if err := server.Serve(unixListener); err != nil {
-				level.Error(logger).Log("err", err)
-				os.Exit(1)
-			}
-		}()
-		<-done
-		level.Info(logger).Log("msg", "Connection closed", "path", *socketPath)
+		serve = func() error {
+			return server.Serve(unixListener)
+		}
 	}
+	go func() {
+		if err := serve(); err != nil {
+			level.Error(logger).Log("err", err)
+			os.Exit(1)
+		}
+	}()
+	<-done
+	level.Info(logger).Log("msg", "Connection closed on", humanAddress)
 	server.Close()
 	os.Exit(0)
 }

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -222,7 +222,6 @@ func main() {
 		os.Chmod(*socketPath, os.FileMode(*socketPermissions))
 		go func() {
 			err = server.Serve(unixListener)
-			println(err)
 			if err != nil && err != http.ErrServerClosed {
 				level.Error(logger).Log("err", err)
 				os.Exit(1)
@@ -231,7 +230,7 @@ func main() {
 
 		<-done
 		level.Info(logger).Log("msg", "Connection closed", "path", *socketPath)
-		unixListener.Close()
+		server.Close()
 		os.Exit(0)
 	}
 }

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -219,7 +219,11 @@ func main() {
 			level.Error(logger).Log("err", err)
 			os.Exit(1)
 		}
-		os.Chmod(*socketPath, os.FileMode(*socketPermissions))
+		err = os.Chmod(*socketPath, os.FileMode(*socketPermissions))
+		if err != nil {
+			level.Error(logger).Log("err", err)
+			os.Exit(1)
+		}
 		go func() {
 			err = server.Serve(unixListener)
 			if err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
- Added parameter `web.socket-path` which sets path to an unix socket file. The program uses http server if the parameter is empty.
- Added parameter `web.socket-permissions` which sets file permissions to an unix socket file. Default value is `0640`.
- e2e tests also checks work of `node_exporter` with unix socket.