### PR TITLE
docs(CLAUDE.md): document in-repo integration tests; build via Build …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,15 @@ Run from the repo root (`/root/ai-workspace/node_exporter/`):
 | `make test-e2e` | Run the e2e harness (downloads collector fixtures on first run) |
 | `make checkmetrics && make checkrules` | Validate metric and rule schemas |
 
+**Integration/e2e tests** live in this repo: the harness `end-to-end-test.sh` (run via `make test-e2e`, exercised twice per build over TCP and the unix socket) plus the `collector/` fixtures. They are shipped as the versioned tests subpackage to `/opt/node_exporter_tests/` and consumed by the CloudLinux QA pipeline.
+
 ## Build System
 
-This repo ships as an RPM/DEB package: `node_exporter`. **Use the `/build-create` skill to submit builds** — it runs `build-plan.py` and submits the payload via the Build System CLI. The tables below are the project-specific overrides on top of that generic flow.
+This repo ships as an RPM/DEB package: `node_exporter`. **Builds are created through the CloudLinux Build System API via the `/build-create` skill** — the skill assembles the build payload and submits it to the Build System. The tables below are the project-specific overrides on top of that generic flow.
 
 ### Parameters
 
-Most fields come from `build-plan.py`; the table records what should end up in the final payload for a `node_exporter`-only build.
+The `/build-create` skill fills most fields automatically; the table records what should end up in the final payload for a `node_exporter`-only build.
 
 | Field | Value |
 | --- | --- |
@@ -87,15 +89,14 @@ Most fields come from `build-plan.py`; the table records what should end up in t
 | `build_platforms` | `CL7`, `CL8`, `CL9`, `CL10`, `ubuntu22_04_ext_cpanel` |
 | `build_flavors` | `alt-php-els` (id `68b1ad89aa0264b2618434c8`) |
 | `target_channel` | `beta` |
-| `build_ref.name` | **Branch (or tag) to build.** `build-plan.py` reads this from the current `git` checkout in the workspace — confirm you are on the intended branch (your feature branch, not `master`) before generating the plan. |
+| `build_ref.name` | **Branch (or tag) to build.** Taken from the current `git` checkout in the workspace — confirm you are on the intended branch (your feature branch, not `master`) before creating the build. |
 | `build_ref.type` | `git_branch` or `git_tag`. |
-| `testing.qa_ref` (per project) and top-level `qa_ref` | **Branch checked out in the QA repo for Jenkins jobs.** `build-plan.py` defaults both to `"master"` regardless of `build_ref.name` — override to your feature branch if the QA side has matching changes. |
+| `testing.qa_ref` (per project) and top-level `qa_ref` | **Branch checked out in the QA repo for Jenkins jobs.** Defaults both to `"master"` regardless of `build_ref.name` — override to your feature branch if the QA side has matching changes. |
 
 ### Jenkins jobs (node_exporter-relevant)
 
-`build-plan.py` emits the workspace-wide plan covering every project in the workspace. For a `node_exporter`-only build, filter `projects[]` down to `node_exporter` and keep **only** these jobs in `jenkins_jobs[]`:
+The `/build-create` skill generates the workspace-wide plan covering every project in the workspace. For a `node_exporter`-only build, filter `projects[]` down to `node_exporter` and keep **only** these jobs in `jenkins_jobs[]`:
 
 | Job name | Build System `_id` |
 | --- | --- |
 | `CMT-end-server-tools` | `635b962c2afd3e1feec603bd` |
-| `clpro-ubuntu-tests` | `677e40a2f1b69faa0d69baf6` |


### PR DESCRIPTION
…System API + /build-create skill

- Remove the clpro-ubuntu-tests Jenkins job row (where present)
- State integration tests live in the project repo and specify the path
- Replace build-plan.py references with the Build System API and the /build-create skill (build-data tables kept intact)